### PR TITLE
User docker system package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Optional:
 - `minio_s3_gateway_bucket`: The bucket to use in the helper scripts if `minio_s3_gateway_install_client` is enabled, default `test`
 - `minio_s3_gateway_placeholder_content`: Content of a `README.txt` file that is copied to a new subdirectory if `minio_s3_gateway_install_client` is enabled
 - `minio_s3_gateway_port`: Listen on this port, default `9000`
-- `docker_version`: The version of Python library for the Docker Engine API, default `7.0.0`
 
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,6 @@ minio_s3_gateway_placeholder_content: "Hello!"
 
 minio_s3_gateway_port: 9000
 
-docker_version: 7.0.0
-
 ######################################################################
 # Expert users only!
 ######################################################################

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,24 @@
 # minio S3 gateway with custom users in front of an external S3 store
 # https://github.com/minio/minio/issues/8045
 
+
+- name: Import a key for epel
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+
+- name: Setup dnf repository, epel
+  become: true
+  ansible.builtin.dnf:
+    update_cache: true
+    name:
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state: present
+
 - name: Install docker
   become: true
-  ansible.builtin.pip:
-    name: docker
-    version: "{{ docker_version }}"
+  ansible.builtin.dnf:
+    name: python3-docker
     state: present
 
 - name: Create docker network


### PR DESCRIPTION
I think it is a good idea to use `python3-docker` system package instead of installing `docker` using `pip `to avoid an issue which we may have in the future similar to https://github.com/ome/ansible-role-anonymous-ftp/pull/8